### PR TITLE
Clean stale Next builds and fix WidgetCard mount state

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "prebuild": "node -e \"require('fs').rmSync('.next', { recursive: true, force: true })\"",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/src/components/WidgetCard.tsx
+++ b/src/components/WidgetCard.tsx
@@ -8,7 +8,7 @@ export default function WidgetCard({ widgetUrl }: { widgetUrl: string }) {
 
   useEffect(() => {
     setHasLoaded(true);
-  });
+  }, []);
 
   return (
     <div
@@ -44,6 +44,8 @@ export default function WidgetCard({ widgetUrl }: { widgetUrl: string }) {
           <iframe
             className="mb-4 h-[445px] w-full rounded-2xl border bg-transparent py-4 px-2 md:py-5 md:px-5 dark:border-stone-700"
             src={widgetUrl}
+            title="Widget preview"
+            loading="lazy"
           ></iframe>
         )
       }


### PR DESCRIPTION
- clean .next before each production build so stale pages-router artifacts do not break app-router builds\n- run WidgetCard's hasLoaded effect only once on mount instead of on every render\n- add iframe title and lazy loading for a lighter, more accessible preview