### PR TITLE
[6] Match the theme color to the app background

### DIFF
--- a/e2e/cuj.navigation.spec.ts
+++ b/e2e/cuj.navigation.spec.ts
@@ -19,3 +19,39 @@ test("time route CUJ loads and card link is present on home", async ({ page }) =
   await expect(page).toHaveURL(/\/time$/);
   await expect(page.getByRole("heading", { name: /countdown/i })).toBeVisible();
 });
+
+test.describe("theme color metadata", () => {
+  test("light mode theme color matches the page background", async ({ page }) => {
+    await page.emulateMedia({ colorScheme: "light" });
+    await page.goto("/");
+
+    await expect(
+      page.locator(
+        'meta[name="theme-color"][media="(prefers-color-scheme: light)"]'
+      )
+    ).toHaveAttribute("content", "#d0faec");
+
+    await expect
+      .poll(async () =>
+        page.evaluate(() => getComputedStyle(document.body).backgroundColor)
+      )
+      .toBe("rgb(208, 250, 236)");
+  });
+
+  test("dark mode theme color matches the page background", async ({ page }) => {
+    await page.emulateMedia({ colorScheme: "dark" });
+    await page.goto("/");
+
+    await expect(
+      page.locator(
+        'meta[name="theme-color"][media="(prefers-color-scheme: dark)"]'
+      )
+    ).toHaveAttribute("content", "#0c0a09");
+
+    await expect
+      .poll(async () =>
+        page.evaluate(() => getComputedStyle(document.body).backgroundColor)
+      )
+      .toBe("rgb(12, 10, 9)");
+  });
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,13 +16,13 @@
 
 html,
 body {
-  background-color: white;
+  background-color: #d0faec;
 }
 
 @media (prefers-color-scheme: dark) {
   html,
   body {
-    background-color: black;
+    background-color: #0c0a09;
   }
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,8 +4,8 @@ import type { Viewport } from "next";
 
 export const viewport: Viewport = {
   themeColor: [
-    { media: "(prefers-color-scheme: dark)", color: "black" },
-    { media: "(prefers-color-scheme: light)", color: "white" },
+    { media: "(prefers-color-scheme: dark)", color: "#0c0a09" },
+    { media: "(prefers-color-scheme: light)", color: "#d0faec" },
   ],
 };
 


### PR DESCRIPTION
- Fix the root page theme-color metadata so it matches the app shell background in light and dark mode
- Update the html/body fallback background colors to match the same app shell colors
- Add Playwright coverage for the generated theme-color metadata and page background in both color schemes

Fixes #6