### PR TITLE
[8] Remove gradient background

### DIFF
--- a/e2e/cuj.navigation.spec.ts
+++ b/e2e/cuj.navigation.spec.ts
@@ -19,3 +19,21 @@ test("time route CUJ loads and card link is present on home", async ({ page }) =
   await expect(page).toHaveURL(/\/time$/);
   await expect(page.getByRole("heading", { name: /countdown/i })).toBeVisible();
 });
+
+test("theme color matches the page background in light and dark mode", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await expect(
+    page.locator(
+      'meta[name="theme-color"][media="(prefers-color-scheme: light)"]',
+    ),
+  ).toHaveAttribute("content", "#d0faec");
+
+  await expect(
+    page.locator(
+      'meta[name="theme-color"][media="(prefers-color-scheme: dark)"]',
+    ),
+  ).toHaveAttribute("content", "#082f49");
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,17 +12,22 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
+  --page-background: #d0faec;
 }
 
 html,
 body {
-  background-color: white;
+  background-color: var(--page-background);
 }
 
 @media (prefers-color-scheme: dark) {
+  :root {
+    --page-background: #082f49;
+  }
+
   html,
   body {
-    background-color: black;
+    background-color: var(--page-background);
   }
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,10 +2,13 @@ import "./globals.css";
 import { Analytics } from "@vercel/analytics/react";
 import type { Viewport } from "next";
 
+const lightThemeColor = "#d0faec";
+const darkThemeColor = "#082f49";
+
 export const viewport: Viewport = {
   themeColor: [
-    { media: "(prefers-color-scheme: dark)", color: "black" },
-    { media: "(prefers-color-scheme: light)", color: "white" },
+    { media: "(prefers-color-scheme: dark)", color: darkThemeColor },
+    { media: "(prefers-color-scheme: light)", color: lightThemeColor },
   ],
 };
 

--- a/src/components/HomeLayout.css
+++ b/src/components/HomeLayout.css
@@ -1,6 +1,0 @@
-@tailwind components;
-@layer components {
-  .simple-gradient {
-    @apply bg-gradient-to-br from-emerald-50 to-pink-50 dark:from-cyan-950/50 dark:to-stone-900/50;
-  }
-}

--- a/src/components/HomeLayout.tsx
+++ b/src/components/HomeLayout.tsx
@@ -1,7 +1,6 @@
 import Image from "next/image";
 import { Inter } from "next/font/google";
 import Copyright from "./Copyright";
-import "./HomeLayout.css";
 import React from "react";
 import Link from "next/link";
 
@@ -26,11 +25,8 @@ export default function HomeLayout({
 }) {
   return (
     <main
-      className={`${font.className} relative flex h-fit min-h-svh flex-col items-center justify-between bg-[#d0faec] p-4 text-slate-700 md:p-6 dark:bg-stone-950 dark:text-slate-100`}
+      className={`${font.className} relative flex h-fit min-h-svh flex-col items-center justify-between bg-[#d0faec] p-4 text-slate-700 md:p-6 dark:bg-[#082f49] dark:text-slate-100`}
     >
-      <div
-        className={`simple-gradient absolute left-0 top-0 z-0 h-full w-full dark:opacity-50 `}
-      ></div>
       <div className="z-10 flex w-full max-w-6xl select-none flex-row content-center py-10 md:py-5">
         <Image
           src="/favicon.ico"


### PR DESCRIPTION
- Removes the home page gradient overlay and uses solid theme-matched backgrounds instead.
- Sets the light theme color to #d0faec and the dark theme color to #082f49 so the page background and browser theme color stay aligned.
- Adds an end-to-end check that verifies both light and dark theme-color meta tags.